### PR TITLE
fix: failing clippy lint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
 
         let mut axum_notify = shutdown.subscribe();
         let server = axum::serve(listener, router)
-            .with_graceful_shutdown(async move { _ = axum_notify.recv().await });
+            .with_graceful_shutdown(async move { axum_notify.recv().await });
 
         info!("listening for connections on: {}", config.addr);
         tokio::select! {


### PR DESCRIPTION
In contrast to Bors, GitHub merge queue counts skipped checks as successful. At first I had only required the container build check to pass. Since the lint check failed in https://github.com/wuvt/poser/pull/5, the container build check got skipped (a success) and the PR was merged. I've set it up so that both the lint check and build check are required now. This PR is to address the clippy error so the main branch passes all checks again.